### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,44 @@ rootfiles/*
 make_root_tmp.dat
 worksim/*
 ./deut_laget/*
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Vim
+*.swp
+
+# Emacs
+*~
+.\#*
+\#*\#


### PR DESCRIPTION
I updated .gitignore.
This .gitignore will ignore temporary files of emacs, vim, library files of fortran. 